### PR TITLE
Performance para Carregar Imagens

### DIFF
--- a/script.js
+++ b/script.js
@@ -122,7 +122,7 @@ fetch("https://cdn.dreamteam.futbol/cards/lke7itok.csv")
         colecao: COLECAO_MAP[obj.collection],
         collection: obj.collection,
         posicao: obj.posicao.toLowerCase(),
-        imagem: `https://cdn.dreamteam.futbol/cards/dream-cards/${obj.card}.png`
+        imagem: `https://cdn.dreamteam.futbol/cards/dream-cards/${obj.card}.webp`
       })
     }
     console.log(`Loaded ${cartas.length} cards!`)

--- a/script.js
+++ b/script.js
@@ -122,7 +122,7 @@ fetch("https://cdn.dreamteam.futbol/cards/lke7itok.csv")
         colecao: COLECAO_MAP[obj.collection],
         collection: obj.collection,
         posicao: obj.posicao.toLowerCase(),
-        imagem: `https://cdn.dreamteam.futbol/cards/${obj.card}.png`
+        imagem: `https://cdn.dreamteam.futbol/cards/dream-cards/${obj.card}.png`
       })
     }
     console.log(`Loaded ${cartas.length} cards!`)


### PR DESCRIPTION
Agora na CDN existe um endpoint para carregar as imagens com tamanho reduzido e em formato webp. Além disso, agora a CDN usa cabeçalhos de caching corretos.

Com as mudanças da CDN e este PR, o tempo que o site demora para carregar todas as imagens (usando minha internet) passa de 1.8 minutos (119MB) para 14.16 segundos (apenas 5.6MB)!